### PR TITLE
chore: .gitignore updated with IntelliJ project files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,24 +1,85 @@
-# Compiled class file
-*.class
-
-# Log file
+# General
 *.log
+*.bak
+*.tmp
+logs
 
-# BlueJ files
-*.ctxt
+### Mac OS
+.DS_Store
 
-# Mobile Tools for Java (J2ME)
-.mtj.tmp/
+# JetBrains
+cmake-build-*/
 
-# Package Files #
-*.jar
-*.war
-*.nar
-*.ear
-*.zip
-*.tar.gz
-*.rar
+### IntelliJ IDEA
+.idea
+*.iws
+*.iml
+*.ipr
+out/
+!**/src/main/**/out/
+!**/src/test/**/out/
 
-# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
-hs_err_pid*
-replay_pid*
+## PyCharm
+*.iml
+modules.xml
+.idea/misc.xml
+*.ipr
+
+### ReSharper 
+_ReSharper*/
+*.[Rr]e[Ss]harper
+*.DotSettings.user
+
+### Rider
+*.sln.iml
+
+# Java / Spring
+HELP.md
+.gradle
+build/
+!gradle/wrapper/gradle-wrapper.jar
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+# Javascript / Typescript
+.env
+.env.development.local
+.env.test.local
+.env.production.local
+.env.local
+node_modules
+
+# Visual Studio 
+*.rsuser
+*.suo
+*.user
+*.userosscache
+*.sln.docstates
+
+### Visual Studio 2015/2017 cache/options directory
+.vs/
+# Uncomment if you have tasks that create the project's static files in wwwroot
+#wwwroot/
+
+### Visual Studio 2017 auto generated files
+Generated\ Files/
+
+### NUnit
+*.VisualState.xml
+TestResult.xml
+nunit-*.xml
+
+# Visual Studio Code
+.vscode/*
+#!.vscode/settings.json
+#!.vscode/tasks.json
+#!.vscode/launch.json
+#!.vscode/extensions.json
+#!.vscode/*.code-snippets
+*.code-workspace
+
+### Local History for Visual Studio Code
+.history/
+
+### Built Visual Studio Code Extensions
+*.vsix


### PR DESCRIPTION
.gitignore file updated to prevent adding files accidentally upon opening the backend project in the root folder.
Files such as .idea and .build now won't be included in commits.