### PR TITLE
fix: typo fixed in expression "Bearer  "

### DIFF
--- a/src/main/java/com/greenfox/dramacsoport/petclinicbackend/config/webtoken/JwtAuthenticationFilter.java
+++ b/src/main/java/com/greenfox/dramacsoport/petclinicbackend/config/webtoken/JwtAuthenticationFilter.java
@@ -31,7 +31,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             return;
         }
 
-        String bearer = "Bearer  "; // this is just a prefix, the actual token starts from the 7th character
+        String bearer = "Bearer "; // this is just a prefix, the actual token starts from the 7th character
         String jwt = authHeader.substring(bearer.length());
         String username = jwtService.extractUsername(jwt);
         if (username != null && SecurityContextHolder.getContext().getAuthentication() == null) {


### PR DESCRIPTION
Authorization in home pages unsuccessful caused by a typo in JwtAuthenticationFilter class (line 34):
"Bearer " (with 2 spaces).

1 space removed, issue fixed. #35 