### PR TITLE
role extraction from token and JwtService test fully implemented

### DIFF
--- a/src/main/java/com/greenfox/dramacsoport/petclinicbackend/config/JwtAuthenticationFilter.java
+++ b/src/main/java/com/greenfox/dramacsoport/petclinicbackend/config/JwtAuthenticationFilter.java
@@ -1,11 +1,12 @@
-package com.greenfox.dramacsoport.petclinicbackend.config.webtoken;
+package com.greenfox.dramacsoport.petclinicbackend.config;
 
 import com.greenfox.dramacsoport.petclinicbackend.services.AppUserDetailsService;
+import com.greenfox.dramacsoport.petclinicbackend.services.JwtService;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -16,12 +17,12 @@ import org.springframework.web.filter.OncePerRequestFilter;
 import java.io.IOException;
 
 @Configuration
+@RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
-    @Autowired
-    private JwtService jwtService;
-    @Autowired
-    private AppUserDetailsService appUserDetailsService;
+    private final JwtService jwtService;
+
+    private final AppUserDetailsService appUserDetailsService;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {

--- a/src/main/java/com/greenfox/dramacsoport/petclinicbackend/config/SecurityConfig.java
+++ b/src/main/java/com/greenfox/dramacsoport/petclinicbackend/config/SecurityConfig.java
@@ -1,6 +1,5 @@
 package com.greenfox.dramacsoport.petclinicbackend.config;
 
-import com.greenfox.dramacsoport.petclinicbackend.config.webtoken.JwtAuthenticationFilter;
 import com.greenfox.dramacsoport.petclinicbackend.services.AppUserDetailsService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;

--- a/src/main/java/com/greenfox/dramacsoport/petclinicbackend/errors/UnIdentifiableRoleException.java
+++ b/src/main/java/com/greenfox/dramacsoport/petclinicbackend/errors/UnIdentifiableRoleException.java
@@ -1,0 +1,15 @@
+package com.greenfox.dramacsoport.petclinicbackend.errors;
+
+/**
+ * This exception should be used when a role cannot be identified from a String (e.g when extracting from a token)
+ */
+public class UnIdentifiableRoleException extends RuntimeException {
+    /**
+     * Constructs a new runtime exception with {@code Role cannot be retrieved!} as its
+     * detail message.  The cause is not initialized, and may subsequently be
+     * initialized by a call to {@link #initCause}.
+     */
+    public UnIdentifiableRoleException() {
+        super("Role cannot be retrieved!");
+    }
+}

--- a/src/main/java/com/greenfox/dramacsoport/petclinicbackend/models/Role.java
+++ b/src/main/java/com/greenfox/dramacsoport/petclinicbackend/models/Role.java
@@ -1,5 +1,14 @@
 package com.greenfox.dramacsoport.petclinicbackend.models;
 
 public enum Role {
-    USER, ADMIN, VET
+    USER, ADMIN, VET;
+
+    public static Role fromString(String role) throws IllegalArgumentException {
+        return switch (role) {
+            case "USER" -> USER;
+            case "ADMIN" -> ADMIN;
+            case "VET" -> VET;
+            default -> throw new IllegalArgumentException("Invalid role: " + role);
+        };
+    }
 }

--- a/src/main/java/com/greenfox/dramacsoport/petclinicbackend/services/AppUserServiceImpl.java
+++ b/src/main/java/com/greenfox/dramacsoport/petclinicbackend/services/AppUserServiceImpl.java
@@ -1,6 +1,5 @@
 package com.greenfox.dramacsoport.petclinicbackend.services;
 
-import com.greenfox.dramacsoport.petclinicbackend.config.webtoken.JwtService;
 import com.greenfox.dramacsoport.petclinicbackend.dtos.LoginRequestDTO;
 import com.greenfox.dramacsoport.petclinicbackend.dtos.RegisterRequestDTO;
 import com.greenfox.dramacsoport.petclinicbackend.models.AppUser;

--- a/src/main/java/com/greenfox/dramacsoport/petclinicbackend/services/AppUserServiceImpl.java
+++ b/src/main/java/com/greenfox/dramacsoport/petclinicbackend/services/AppUserServiceImpl.java
@@ -110,8 +110,9 @@ public class AppUserServiceImpl implements AppUserService {
     @Override
     public LoginResponseDTO login(LoginRequestDTO requestDTO) throws UsernameNotFoundException {
         if (authenticateUser(requestDTO)) {
-            return new LoginResponseDTO(jwtService.generateToken(loadUserByUsername(requestDTO.email())),
-                    loadUserByUsername((requestDTO.email())).getAuthorities().iterator().next().getAuthority());
+            UserDetails userDetails = loadUserByUsername(requestDTO.email());
+            String token = jwtService.generateToken(userDetails);
+            return new LoginResponseDTO(token, jwtService.extractRole(token).toString());
         }
         throw new UsernameNotFoundException("Authentication failed!");
     }

--- a/src/main/java/com/greenfox/dramacsoport/petclinicbackend/services/JwtService.java
+++ b/src/main/java/com/greenfox/dramacsoport/petclinicbackend/services/JwtService.java
@@ -1,6 +1,5 @@
 package com.greenfox.dramacsoport.petclinicbackend.services;
 
-import com.greenfox.dramacsoport.petclinicbackend.errors.UnIdentifiableRoleException;
 import com.greenfox.dramacsoport.petclinicbackend.models.Role;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
@@ -52,14 +51,7 @@ public class JwtService {
     public Role extractRole(String jwt) {
         Claims claims = getClaims(jwt);
         String roleAsString = claims.get("role", String.class);
-        Role role;
-        switch (roleAsString) {
-            case "USER" -> role = Role.USER;
-            case "VET" -> role = Role.VET;
-            case "ADMIN" -> role = Role.ADMIN;
-            default -> throw new UnIdentifiableRoleException();
-        }
-        return role;
+        return Role.fromString(roleAsString);
     }
 
     private Claims getClaims(String jwt) {

--- a/src/main/java/com/greenfox/dramacsoport/petclinicbackend/services/JwtService.java
+++ b/src/main/java/com/greenfox/dramacsoport/petclinicbackend/services/JwtService.java
@@ -3,7 +3,6 @@ package com.greenfox.dramacsoport.petclinicbackend.services;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
@@ -18,7 +17,6 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 @Service
-@Configuration
 public class JwtService {
     private final String secretKey = secretKeyGenerator();
     private static final long VALIDITY = TimeUnit.MINUTES.toMillis(30);
@@ -27,7 +25,9 @@ public class JwtService {
         Map<String, String> claims = new HashMap<>();
         GrantedAuthority firstAuthority = userDetails.getAuthorities().iterator().next();
         String firstAuthorityName = firstAuthority.getAuthority();
-        claims.put("role", firstAuthorityName);
+        String rolePrefix = "ROLE_";
+        String roleNameAsString = firstAuthorityName.substring(rolePrefix.length());
+        claims.put("role", roleNameAsString);
         return Jwts.builder()
                 .claims(claims)
                 .subject(userDetails.getUsername())

--- a/src/main/java/com/greenfox/dramacsoport/petclinicbackend/services/JwtService.java
+++ b/src/main/java/com/greenfox/dramacsoport/petclinicbackend/services/JwtService.java
@@ -1,5 +1,7 @@
 package com.greenfox.dramacsoport.petclinicbackend.services;
 
+import com.greenfox.dramacsoport.petclinicbackend.errors.UnIdentifiableRoleException;
+import com.greenfox.dramacsoport.petclinicbackend.models.Role;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
@@ -45,6 +47,19 @@ public class JwtService {
     public String extractUsername(String jwt) {
         Claims claims = getClaims(jwt);
         return claims.getSubject();
+    }
+
+    public Role extractRole(String jwt) {
+        Claims claims = getClaims(jwt);
+        String roleAsString = claims.get("role", String.class);
+        Role role;
+        switch (roleAsString) {
+            case "USER" -> role = Role.USER;
+            case "VET" -> role = Role.VET;
+            case "ADMIN" -> role = Role.ADMIN;
+            default -> throw new UnIdentifiableRoleException();
+        }
+        return role;
     }
 
     private Claims getClaims(String jwt) {

--- a/src/main/java/com/greenfox/dramacsoport/petclinicbackend/services/JwtService.java
+++ b/src/main/java/com/greenfox/dramacsoport/petclinicbackend/services/JwtService.java
@@ -1,4 +1,4 @@
-package com.greenfox.dramacsoport.petclinicbackend.config.webtoken;
+package com.greenfox.dramacsoport.petclinicbackend.services;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;

--- a/src/test/java/com/greenfox/dramacsoport/petclinicbackend/JwtServiceTest.java
+++ b/src/test/java/com/greenfox/dramacsoport/petclinicbackend/JwtServiceTest.java
@@ -1,6 +1,8 @@
 package com.greenfox.dramacsoport.petclinicbackend;
 
-import com.greenfox.dramacsoport.petclinicbackend.config.webtoken.JwtService;
+
+import com.greenfox.dramacsoport.petclinicbackend.models.Role;
+import com.greenfox.dramacsoport.petclinicbackend.services.JwtService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -10,8 +12,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 
 import java.util.Collections;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 public class JwtServiceTest {
@@ -20,17 +21,15 @@ public class JwtServiceTest {
     private JwtService jwtService;
 
     @Test
-    public void testJwtTokenGeneration() {
-        UserDetails userDetails = new User(
-                "testUser",
-                "password",
-                Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER"))
-        );
+    public void shouldCheckIfTokenIsValid() {
+        UserDetails userDetails = User.builder()
+                .username("testUser")
+                .password("password")
+                .roles(Role.USER.toString())
+                .build();
 
         String token = jwtService.generateToken(userDetails);
-        String username = jwtService.extractUsername(token);
 
-        assertEquals(userDetails.getUsername(), username);
         assertTrue(jwtService.isTokenValid(token));
     }
 }

--- a/src/test/java/com/greenfox/dramacsoport/petclinicbackend/JwtServiceTest.java
+++ b/src/test/java/com/greenfox/dramacsoport/petclinicbackend/JwtServiceTest.java
@@ -1,16 +1,19 @@
 package com.greenfox.dramacsoport.petclinicbackend;
 
 
+import com.greenfox.dramacsoport.petclinicbackend.errors.UnIdentifiableRoleException;
 import com.greenfox.dramacsoport.petclinicbackend.models.Role;
 import com.greenfox.dramacsoport.petclinicbackend.services.JwtService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 
 import java.util.Collections;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -31,5 +34,51 @@ public class JwtServiceTest {
         String token = jwtService.generateToken(userDetails);
 
         assertTrue(jwtService.isTokenValid(token));
+    }
+
+    @Test
+    public void shouldGetUsername() {
+        UserDetails userDetails = User.builder()
+                .username("testUser")
+                .password("password")
+                .roles(Role.USER.toString())
+                .build();
+
+        String token = jwtService.generateToken(userDetails);
+
+        String username = jwtService.extractUsername(token);
+        assertEquals(userDetails.getUsername(), username);
+    }
+
+    @Test
+    public void shouldGetValidRoles() {
+        for (Role role : Role.values()) {
+            UserDetails testUser = User.builder()
+                    .username("testUser")
+                    .password("password")
+                    .roles(role.toString())
+                    .build();
+
+            String token = jwtService.generateToken(testUser);
+
+            Role extractedRole = jwtService.extractRole(token);
+            GrantedAuthority authority = new SimpleGrantedAuthority("ROLE_" + extractedRole.name());
+            Set<GrantedAuthority> authorities = Collections.singleton(authority);
+
+            assertEquals(testUser.getAuthorities(), authorities);
+        }
+    }
+
+    @Test
+    public void shouldGetInvalidRole() {
+        UserDetails testUser = User.builder()
+                .username("testUser")
+                .password("password")
+                .roles("Invalid_ROLE")
+                .build();
+
+        String token = jwtService.generateToken(testUser);
+
+        assertThrows(UnIdentifiableRoleException.class, () -> jwtService.extractRole(token));
     }
 }

--- a/src/test/java/com/greenfox/dramacsoport/petclinicbackend/JwtServiceTest.java
+++ b/src/test/java/com/greenfox/dramacsoport/petclinicbackend/JwtServiceTest.java
@@ -1,7 +1,5 @@
 package com.greenfox.dramacsoport.petclinicbackend;
 
-
-import com.greenfox.dramacsoport.petclinicbackend.errors.UnIdentifiableRoleException;
 import com.greenfox.dramacsoport.petclinicbackend.models.Role;
 import com.greenfox.dramacsoport.petclinicbackend.services.JwtService;
 import org.junit.jupiter.api.Test;
@@ -79,6 +77,6 @@ public class JwtServiceTest {
 
         String token = jwtService.generateToken(testUser);
 
-        assertThrows(UnIdentifiableRoleException.class, () -> jwtService.extractRole(token));
+        assertThrows(IllegalArgumentException.class, () -> jwtService.extractRole(token));
     }
 }

--- a/src/test/java/com/greenfox/dramacsoport/petclinicbackend/controllers/LoginControllerTest.java
+++ b/src/test/java/com/greenfox/dramacsoport/petclinicbackend/controllers/LoginControllerTest.java
@@ -1,9 +1,9 @@
 package com.greenfox.dramacsoport.petclinicbackend.controllers;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.greenfox.dramacsoport.petclinicbackend.dtos.LoginRequestDTO;
 import com.greenfox.dramacsoport.petclinicbackend.models.AppUser;
 import com.greenfox.dramacsoport.petclinicbackend.repositories.AppUserRepository;
-import com.greenfox.dramacsoport.petclinicbackend.dtos.LoginRequestDTO;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -12,12 +12,12 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.web.servlet.MockMvc;
-import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+
 import java.util.Optional;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -49,7 +49,7 @@ public class LoginControllerTest {
                         status().isOk(),
                         content().contentType(MediaType.APPLICATION_JSON),
                         jsonPath("$.token").isString(),
-                        jsonPath("$.role").value("ROLE_USER"));
+                        jsonPath("$.role").value("USER"));
     }
 
     @Test

--- a/src/test/java/com/greenfox/dramacsoport/petclinicbackend/services/JwtServiceTest.java
+++ b/src/test/java/com/greenfox/dramacsoport/petclinicbackend/services/JwtServiceTest.java
@@ -1,7 +1,6 @@
-package com.greenfox.dramacsoport.petclinicbackend;
+package com.greenfox.dramacsoport.petclinicbackend.services;
 
 import com.greenfox.dramacsoport.petclinicbackend.models.Role;
-import com.greenfox.dramacsoport.petclinicbackend.services.JwtService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;


### PR DESCRIPTION
Changes in token generation:
- role is now saved into the token as is, without the ROLE_ prefix
- role extraction method added to the JwtService
- custom UnIdentifiableRoleException added to handle unknown role extraction

JwtServiceTest (unit test):
- token generation test stripped down to check only if it is created valid.
- UserDetails building is done with builder method
- username and role extraction tests have been also added