### PR TITLE
fix+refactor: AppUserRepository returns Optional<AppUser> + some validation patches

### DIFF
--- a/src/main/java/com/greenfox/dramacsoport/petclinicbackend/config/JwtAuthenticationFilter.java
+++ b/src/main/java/com/greenfox/dramacsoport/petclinicbackend/config/JwtAuthenticationFilter.java
@@ -1,7 +1,6 @@
 package com.greenfox.dramacsoport.petclinicbackend.config;
 
 import com.greenfox.dramacsoport.petclinicbackend.errors.AppServiceErrors;
-import com.greenfox.dramacsoport.petclinicbackend.models.AppUser;
 import com.greenfox.dramacsoport.petclinicbackend.repositories.AppUserRepository;
 import com.greenfox.dramacsoport.petclinicbackend.services.JwtService;
 import jakarta.servlet.FilterChain;
@@ -29,13 +28,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final AppUserRepository appUserRepository;
 
     UserDetailsService userDetailsService() {
-        return (username) -> {
-            AppUser user = appUserRepository.findByEmail(username);
-            if (user == null) {
-                throw new UsernameNotFoundException(AppServiceErrors.USERNAME_NOT_FOUND + username);
-            }
-            return user;
-        };
+        return (username) -> appUserRepository.findByEmail(username).orElseThrow(() -> new UsernameNotFoundException(AppServiceErrors.USERNAME_NOT_FOUND + username));
     }
 
     @Override

--- a/src/main/java/com/greenfox/dramacsoport/petclinicbackend/config/SecurityConfig.java
+++ b/src/main/java/com/greenfox/dramacsoport/petclinicbackend/config/SecurityConfig.java
@@ -1,7 +1,6 @@
 package com.greenfox.dramacsoport.petclinicbackend.config;
 
 import com.greenfox.dramacsoport.petclinicbackend.errors.AppServiceErrors;
-import com.greenfox.dramacsoport.petclinicbackend.models.AppUser;
 import com.greenfox.dramacsoport.petclinicbackend.repositories.AppUserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -69,13 +68,7 @@ public class SecurityConfig implements WebMvcConfigurer {
 
     @Bean
     UserDetailsService userDetailsService() {
-        return (username) -> {
-            AppUser user = appUserRepository.findByEmail(username);
-            if (user == null) {
-                throw new UsernameNotFoundException(AppServiceErrors.USERNAME_NOT_FOUND + username);
-            }
-            return user;
-        };
+        return (username) -> appUserRepository.findByEmail(username).orElseThrow(() -> new UsernameNotFoundException(AppServiceErrors.USERNAME_NOT_FOUND + username));
     }
 
     @Bean

--- a/src/main/java/com/greenfox/dramacsoport/petclinicbackend/dtos/login/LoginRequestDTO.java
+++ b/src/main/java/com/greenfox/dramacsoport/petclinicbackend/dtos/login/LoginRequestDTO.java
@@ -4,15 +4,12 @@ import com.greenfox.dramacsoport.petclinicbackend.errors.AppServiceErrors;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.constraints.NotNull;
 
 public record LoginRequestDTO(
         @NotBlank(message = "Email field is required.")
-        @NotNull(message = "Email field is required.")
         @Email(message = AppServiceErrors.EMAIL_FIELD_NOT_VALID)
         String email,
 
         @NotEmpty(message = "Password field is required.")
-        @NotNull(message = "Password field is required.")
         String password) {
 }

--- a/src/main/java/com/greenfox/dramacsoport/petclinicbackend/dtos/pet/PetDTO.java
+++ b/src/main/java/com/greenfox/dramacsoport/petclinicbackend/dtos/pet/PetDTO.java
@@ -2,7 +2,6 @@ package com.greenfox.dramacsoport.petclinicbackend.dtos.pet;
 
 import jakarta.validation.constraints.Future;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PastOrPresent;
 import lombok.Data;
 
@@ -10,19 +9,16 @@ import java.time.LocalDate;
 
 @Data
 public class PetDTO {
-    @NotNull(message = "Pet Name field is required.")
+
     @NotBlank(message = "Pet Name field is required.")
     private String petName;
 
-    @NotNull(message = "Pet Breed field is required.")
     @NotBlank(message = "Pet Breed field is required.")
     private String petBreed;
 
-    @NotNull(message = "Pet Sex field is required.")
     @NotBlank(message = "Pet Sex field is required.")
     private String petSex;
 
-    @NotNull(message = "Pet Birthdate field is required.")
     @NotBlank(message = "Pet Birthdate field is required.")
     @PastOrPresent(message = "Pet Birthdate should be a date in the past or the present day.")
     private LocalDate petBirthDate;

--- a/src/main/java/com/greenfox/dramacsoport/petclinicbackend/dtos/register/RegisterRequestDTO.java
+++ b/src/main/java/com/greenfox/dramacsoport/petclinicbackend/dtos/register/RegisterRequestDTO.java
@@ -4,23 +4,19 @@ import com.greenfox.dramacsoport.petclinicbackend.errors.AppServiceErrors;
 import com.greenfox.dramacsoport.petclinicbackend.models.Role;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Data;
 
 @Data
 public final class RegisterRequestDTO {
-    @NotBlank(message = "Username field is required.")
-    @NotNull(message = "Username field is required.")
+    @NotBlank(message = "Display Name field is required.")
     private final String displayName;
 
     @NotBlank(message = "Email field is required.")
-    @NotNull(message = "Email field is required.")
     @Email(message = AppServiceErrors.EMAIL_FIELD_NOT_VALID)
     private final String email;
 
     @NotBlank(message = "Password field is required.")
-    @NotNull(message = "Password field is required.")
     @Size(min = 3, message = AppServiceErrors.SHORT_PASSWORD)
     private final String password;
 

--- a/src/main/java/com/greenfox/dramacsoport/petclinicbackend/repositories/AppUserRepository.java
+++ b/src/main/java/com/greenfox/dramacsoport/petclinicbackend/repositories/AppUserRepository.java
@@ -2,10 +2,11 @@ package com.greenfox.dramacsoport.petclinicbackend.repositories;
 
 import com.greenfox.dramacsoport.petclinicbackend.models.AppUser;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
+
+import java.util.Optional;
 
 public interface AppUserRepository extends JpaRepository<AppUser, Long> {
-    AppUser findByEmail(String email) throws UsernameNotFoundException;
+    Optional<AppUser> findByEmail(String email);
 
     boolean existsByEmail(String email);
 }

--- a/src/main/java/com/greenfox/dramacsoport/petclinicbackend/services/appUser/AppUserService.java
+++ b/src/main/java/com/greenfox/dramacsoport/petclinicbackend/services/appUser/AppUserService.java
@@ -6,10 +6,14 @@ import com.greenfox.dramacsoport.petclinicbackend.dtos.update.EditUserResponseDT
 import com.greenfox.dramacsoport.petclinicbackend.exceptions.DeletionException;
 import com.greenfox.dramacsoport.petclinicbackend.exceptions.IncorrectPasswordException;
 import com.greenfox.dramacsoport.petclinicbackend.exceptions.InvalidPasswordException;
+import com.greenfox.dramacsoport.petclinicbackend.models.AppUser;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 
 import javax.naming.NameAlreadyBoundException;
 
 public interface AppUserService {
+    AppUser loadUserByEmail(String email) throws UsernameNotFoundException;
+
     DeleteUserResponse deleteUser(String userEmail, Long id) throws DeletionException;
 
     EditUserResponseDTO changeUserData(String email, EditUserRequestDTO editUserRequest) throws IncorrectPasswordException, InvalidPasswordException,

--- a/src/main/java/com/greenfox/dramacsoport/petclinicbackend/services/appUser/auth/AuthServiceImpl.java
+++ b/src/main/java/com/greenfox/dramacsoport/petclinicbackend/services/appUser/auth/AuthServiceImpl.java
@@ -11,6 +11,7 @@ import com.greenfox.dramacsoport.petclinicbackend.exceptions.InvalidPasswordExce
 import com.greenfox.dramacsoport.petclinicbackend.models.AppUser;
 import com.greenfox.dramacsoport.petclinicbackend.repositories.AppUserRepository;
 import com.greenfox.dramacsoport.petclinicbackend.services.JwtService;
+import com.greenfox.dramacsoport.petclinicbackend.services.appUser.AppUserService;
 import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
 import org.slf4j.Logger;
@@ -39,6 +40,8 @@ public class AuthServiceImpl implements AuthService {
     private final JavaMailSender javaMailSender;
 
     private final Logger logger = LoggerFactory.getLogger(LoginController.class);
+
+    private final AppUserService appUserService;
 
     @Value("${spring.mail.username}")
     private String petClinicEmail;
@@ -92,7 +95,7 @@ public class AuthServiceImpl implements AuthService {
         if (!authenticateUser(requestDTO)) {
             throw new IncorrectLoginCredentialsException();
         }
-        AppUser appUser = appUserRepository.findByEmail(requestDTO.email());
+        AppUser appUser = appUserService.loadUserByEmail(requestDTO.email());
         String token = jwtService.generateToken(appUser);
         return new LoginResponseDTO(token);
     }
@@ -101,7 +104,7 @@ public class AuthServiceImpl implements AuthService {
         try {
             return passwordEncoder.matches(
                     requestDTO.password(),
-                    appUserRepository.findByEmail(requestDTO.email()).getPassword()
+                    appUserService.loadUserByEmail(requestDTO.email()).getPassword()
             );
         } catch (UsernameNotFoundException ue) {
             throw new IncorrectLoginCredentialsException();

--- a/src/main/java/com/greenfox/dramacsoport/petclinicbackend/services/petHandling/PetServiceImpl.java
+++ b/src/main/java/com/greenfox/dramacsoport/petclinicbackend/services/petHandling/PetServiceImpl.java
@@ -3,8 +3,8 @@ package com.greenfox.dramacsoport.petclinicbackend.services.petHandling;
 import com.greenfox.dramacsoport.petclinicbackend.dtos.pet.PetDTO;
 import com.greenfox.dramacsoport.petclinicbackend.dtos.pet.PetListResponse;
 import com.greenfox.dramacsoport.petclinicbackend.models.Pet;
-import com.greenfox.dramacsoport.petclinicbackend.repositories.AppUserRepository;
 import com.greenfox.dramacsoport.petclinicbackend.repositories.PetRepository;
+import com.greenfox.dramacsoport.petclinicbackend.services.appUser.AppUserService;
 import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
@@ -16,13 +16,13 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class PetServiceImpl implements PetService{
 
-    private final AppUserRepository appUserRepository;
+    private final AppUserService appUserService;
     private final PetRepository petRepository;
     private final ModelMapper modelMapper = new ModelMapper();
 
     @Override
     public PetListResponse getUserPets(String email) {
-        List<Pet> petList = petRepository.findAllByOwnerId(appUserRepository.findByEmail(email).getId());
+        List<Pet> petList = petRepository.findAllByOwnerId(appUserService.loadUserByEmail(email).getId());
 
         List<PetDTO> petDTOList = petList.stream()
                 .map(pet -> modelMapper.map(pet, PetDTO.class))
@@ -34,7 +34,7 @@ public class PetServiceImpl implements PetService{
     @Override
     public PetDTO addPet(String email, PetDTO petDTO) {
         Pet pet = modelMapper.map(petDTO, Pet.class);
-        pet.setOwner(appUserRepository.findByEmail(email));
+        pet.setOwner(appUserService.loadUserByEmail(email));
         petRepository.save(pet);
         return modelMapper.map(pet, PetDTO.class);
     }

--- a/src/test/java/com/greenfox/dramacsoport/petclinicbackend/config/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/greenfox/dramacsoport/petclinicbackend/config/JwtAuthenticationFilterTest.java
@@ -1,6 +1,5 @@
 package com.greenfox.dramacsoport.petclinicbackend.config;
 
-import com.greenfox.dramacsoport.petclinicbackend.errors.AppServiceErrors;
 import com.greenfox.dramacsoport.petclinicbackend.models.AppUser;
 import com.greenfox.dramacsoport.petclinicbackend.models.Role;
 import com.greenfox.dramacsoport.petclinicbackend.repositories.AppUserRepository;
@@ -24,6 +23,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 
 import java.io.IOException;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -89,7 +89,7 @@ class JwtAuthenticationFilterTest {
         //MOCK CALLS
         when(jwtService.isTokenValid(anyString())).thenReturn(true);
         when(jwtService.extractUsername(anyString())).thenReturn(appUser.getUsername());
-        when(repository.findByEmail(anyString())).thenReturn(appUser);
+        when(repository.findByEmail(anyString())).thenReturn(Optional.of(appUser));
         //WHEN
         jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
 
@@ -231,8 +231,6 @@ class JwtAuthenticationFilterTest {
         //MOCK CALLS
         when(jwtService.isTokenValid(anyString())).thenReturn(true);
         when(jwtService.extractUsername(anyString())).thenReturn(null);
-        when(repository.findByEmail(null))
-                .thenThrow(new UsernameNotFoundException(AppServiceErrors.USERNAME_NOT_FOUND));
 
         //ACT and ASSERT
         assertThrows(UsernameNotFoundException.class, () ->
@@ -261,7 +259,6 @@ class JwtAuthenticationFilterTest {
         //MOCK CALLS
         when(jwtService.isTokenValid(anyString())).thenReturn(true);
         when(jwtService.extractUsername(anyString())).thenReturn(appUser.getUsername());
-        when(repository.findByEmail(anyString())).thenThrow(new UsernameNotFoundException(AppServiceErrors.USERNAME_NOT_FOUND));
 
         //ACT and ASSERT
         assertThrows(UsernameNotFoundException.class,

--- a/src/test/java/com/greenfox/dramacsoport/petclinicbackend/controllers/appUser/LoginControllerTest.java
+++ b/src/test/java/com/greenfox/dramacsoport/petclinicbackend/controllers/appUser/LoginControllerTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.greenfox.dramacsoport.petclinicbackend.dtos.login.LoginRequestDTO;
 import com.greenfox.dramacsoport.petclinicbackend.models.AppUser;
 import com.greenfox.dramacsoport.petclinicbackend.repositories.AppUserRepository;
+import com.greenfox.dramacsoport.petclinicbackend.services.appUser.AppUserService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -25,6 +26,8 @@ public class LoginControllerTest {
     MockMvc mockMvc;
     @MockBean
     AppUserRepository appUserRepository;
+    @MockBean
+    AppUserService appUserService;
     @Autowired
     private ObjectMapper objectMapper;
     @Autowired
@@ -37,7 +40,7 @@ public class LoginControllerTest {
         mockUser.setEmail("xy@example.com");
         mockUser.setPassword(passwordEncoder.encode("ValidPassword1"));
 
-        when(appUserRepository.findByEmail("xy@example.com")).thenReturn(mockUser);
+        when(appUserService.loadUserByEmail("xy@example.com")).thenReturn(mockUser);
 
         LoginRequestDTO loginRequest = new LoginRequestDTO("xy@example.com", "ValidPassword1");
 
@@ -52,7 +55,7 @@ public class LoginControllerTest {
 
     @Test
     public void responseShouldBeForbiddenIfUserNotFound() throws Exception {
-        when(appUserRepository.findByEmail("aaa@example.com")).thenThrow(UsernameNotFoundException.class);
+        when(appUserService.loadUserByEmail("aaa@example.com")).thenThrow(UsernameNotFoundException.class);
 
         LoginRequestDTO loginRequest = new LoginRequestDTO("aaa@example.com", "password");
 
@@ -70,7 +73,7 @@ public class LoginControllerTest {
         mockUser.setEmail("xy@example.com");
         mockUser.setPassword(passwordEncoder.encode("ValidPassword1"));
 
-        when(appUserRepository.findByEmail("xy@example.com")).thenReturn(mockUser);
+        when(appUserService.loadUserByEmail("xy@example.com")).thenReturn(mockUser);
 
         LoginRequestDTO loginRequest = new LoginRequestDTO("xy@example.com", "wrongPassword");
 
@@ -89,7 +92,7 @@ public class LoginControllerTest {
         mockUser.setEmail("xy@example.com");
         mockUser.setPassword(passwordEncoder.encode("ValidPassword1"));
 
-        when(appUserRepository.findByEmail("xy@example.com")).thenReturn(mockUser);
+        when(appUserService.loadUserByEmail("xy@example.com")).thenReturn(mockUser);
 
         LoginRequestDTO loginRequest = new LoginRequestDTO("xy@example.com", "");
 
@@ -108,7 +111,7 @@ public class LoginControllerTest {
         mockUser.setEmail("xy@example.com");
         mockUser.setPassword(passwordEncoder.encode("ValidPassword1"));
 
-        when(appUserRepository.findByEmail("xy@example.com")).thenReturn(mockUser);
+        when(appUserService.loadUserByEmail("xy@example.com")).thenReturn(mockUser);
 
         LoginRequestDTO loginRequest = new LoginRequestDTO("xy@example.com", null);
 
@@ -127,7 +130,7 @@ public class LoginControllerTest {
         mockUser.setEmail("xy@example.com");
         mockUser.setPassword(passwordEncoder.encode("ValidPassword1"));
 
-        when(appUserRepository.findByEmail("xy@example.com")).thenReturn(mockUser);
+        when(appUserService.loadUserByEmail("xy@example.com")).thenReturn(mockUser);
 
         LoginRequestDTO loginRequest = new LoginRequestDTO("", "password");
 

--- a/src/test/java/com/greenfox/dramacsoport/petclinicbackend/controllers/pet/AddPetServiceTest.java
+++ b/src/test/java/com/greenfox/dramacsoport/petclinicbackend/controllers/pet/AddPetServiceTest.java
@@ -3,8 +3,8 @@ package com.greenfox.dramacsoport.petclinicbackend.controllers.pet;
 import com.greenfox.dramacsoport.petclinicbackend.dtos.pet.PetDTO;
 import com.greenfox.dramacsoport.petclinicbackend.models.AppUser;
 import com.greenfox.dramacsoport.petclinicbackend.models.Pet;
-import com.greenfox.dramacsoport.petclinicbackend.repositories.AppUserRepository;
 import com.greenfox.dramacsoport.petclinicbackend.repositories.PetRepository;
+import com.greenfox.dramacsoport.petclinicbackend.services.appUser.AppUserService;
 import com.greenfox.dramacsoport.petclinicbackend.services.petHandling.PetServiceImpl;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -31,7 +31,7 @@ public class AddPetServiceTest {
     private PetRepository petRepository;
 
     @Mock
-    private AppUserRepository appUserRepository;
+    private AppUserService appUserService;
 
     @InjectMocks
     private PetServiceImpl petService;
@@ -60,7 +60,7 @@ public class AddPetServiceTest {
     @Test
     void shouldAddPetSuccessfully() {
 
-        when(appUserRepository.findByEmail(anyString())).thenReturn(appUser);
+        when(appUserService.loadUserByEmail(anyString())).thenReturn(appUser);
         when(petRepository.save(any(Pet.class))).thenReturn(pet);
 
         PetDTO savedPetDTO = petService.addPet("xy@example.com", petDTO);
@@ -68,7 +68,7 @@ public class AddPetServiceTest {
         assertEquals(petDTO.getPetName(), savedPetDTO.getPetName());
         assertEquals(petDTO.getPetBreed(), savedPetDTO.getPetBreed());
 
-        verify(appUserRepository).findByEmail("xy@example.com");
+        verify(appUserService).loadUserByEmail("xy@example.com");
 
         ArgumentCaptor<Pet> petCaptor = forClass(Pet.class);
         verify(petRepository).save(petCaptor.capture());

--- a/src/test/java/com/greenfox/dramacsoport/petclinicbackend/services/appUser/auth/AuthServiceTest.java
+++ b/src/test/java/com/greenfox/dramacsoport/petclinicbackend/services/appUser/auth/AuthServiceTest.java
@@ -6,6 +6,7 @@ import com.greenfox.dramacsoport.petclinicbackend.dtos.register.RegisterRequestD
 import com.greenfox.dramacsoport.petclinicbackend.models.AppUser;
 import com.greenfox.dramacsoport.petclinicbackend.repositories.AppUserRepository;
 import com.greenfox.dramacsoport.petclinicbackend.services.JwtService;
+import com.greenfox.dramacsoport.petclinicbackend.services.appUser.AppUserService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -34,6 +35,9 @@ public class AuthServiceTest {
 
     @Mock
     private AppUserRepository appUserRepository;
+
+    @Mock
+    private AppUserService appUserService;
 
     @Mock
     private PasswordEncoder passwordEncoder;
@@ -102,7 +106,7 @@ public class AuthServiceTest {
         appUser.setPassword("encodedPassword");
 
         // Mock the behavior of finding a user by email
-        when(appUserRepository.findByEmail(loginRequestDTO.email())).thenReturn(appUser);
+        when(appUserService.loadUserByEmail(loginRequestDTO.email())).thenReturn(appUser);
         // Mock the behavior of password matching
         when(passwordEncoder.matches(loginRequestDTO.password(), appUser.getPassword())).thenReturn(true);
         // Mock the behavior of JWT token generation

--- a/src/test/java/com/greenfox/dramacsoport/petclinicbackend/services/appUser/auth/LoginUserTest.java
+++ b/src/test/java/com/greenfox/dramacsoport/petclinicbackend/services/appUser/auth/LoginUserTest.java
@@ -4,8 +4,8 @@ import com.greenfox.dramacsoport.petclinicbackend.dtos.login.LoginRequestDTO;
 import com.greenfox.dramacsoport.petclinicbackend.errors.AppServiceErrors;
 import com.greenfox.dramacsoport.petclinicbackend.exceptions.IncorrectLoginCredentialsException;
 import com.greenfox.dramacsoport.petclinicbackend.models.AppUser;
-import com.greenfox.dramacsoport.petclinicbackend.repositories.AppUserRepository;
 import com.greenfox.dramacsoport.petclinicbackend.services.JwtService;
+import com.greenfox.dramacsoport.petclinicbackend.services.appUser.AppUserService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -25,7 +25,7 @@ import static org.mockito.Mockito.*;
 public class LoginUserTest {
 
     @Mock
-    private AppUserRepository appUserRepository;
+    private AppUserService appUserService;
 
     @Mock
     private PasswordEncoder passwordEncoder;
@@ -50,7 +50,7 @@ public class LoginUserTest {
     @Test
     public void loginMethodFailsWithWrongEmail() {
         // Arrange: Set up a non-matching email scenario
-        when(appUserRepository.findByEmail(loginRequestDTO.email())).thenThrow(UsernameNotFoundException.class);
+        when(appUserService.loadUserByEmail(loginRequestDTO.email())).thenThrow(UsernameNotFoundException.class);
 
         // Act & Assert: Expect an exception due to email mismatch
         assertThrows(IncorrectLoginCredentialsException.class, () -> authService.login(loginRequestDTO));
@@ -66,7 +66,7 @@ public class LoginUserTest {
         appUser.setEmail("test@example.com");
         appUser.setPassword("encodedPassword");
 
-        when(appUserRepository.findByEmail(loginRequestDTO.email())).thenReturn(appUser);
+        when(appUserService.loadUserByEmail(loginRequestDTO.email())).thenReturn(appUser);
         when(passwordEncoder.matches(loginRequestDTO.password(), appUser.getPassword())).thenReturn(false);
 
         // Act & Assert: Expect an exception due to password mismatch


### PR DESCRIPTION
Needed because: the AppUserRepository.findByEmail() did not throw exception, when no user could be found

Solved by:
- AppUserRepository returns Optional<AppUser>

Changes in code:
- UserDetailsService implementations in SecurityConfig and JwtAuthenticationFilter:
          AppUser retrieval changed accordingly
- AppUserService and ...Impl: loadUserByEmail() reintroduced for loading AppUser from DB
- other services: repo method changed to AppUserService.loadUserByEmail()
- DTOs unneeded validations got removed where @notblank or @notempty is in place

- tests: most of the tests now mocks the AppUserService, the rest mocks the AppUserRepository properly